### PR TITLE
Updated dependency. Package jira-python is now jira.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setup(
     description='python build tools for Atlassian Bamboo',
     install_requires=[
         'lxml',
-        'jira-python'
+        'jira'
     ],
 )


### PR DESCRIPTION
The package has been renamed. https://pypi.python.org/pypi/jira-python/ throws an HTTP 404.